### PR TITLE
fix(rulemap): add home-index entry so catch-all route resolves correctly

### DIFF
--- a/provider/labels.go
+++ b/provider/labels.go
@@ -34,6 +34,7 @@ type ServerConfig struct {
 // ruleMap maps rule IDs to Traefik rule expressions
 // Extracted from cmd/generate-routes/main.go:23-37
 var ruleMap = map[string]string{
+	"home-index":        "PathPrefix(`/`)",
 	"home-index-root":   "PathPrefix(`/`)",
 	"home-index-signin": "Path(`/sign-in`) || Path(`/sign-up`)",
 	"home-seo":          "PathPrefix(`/api/seo`)",


### PR DESCRIPTION
## Summary

- `generate-lab-labels.sh` converts `rule=PathPrefix('/')` to `rule_id=<router-name>` because Cloud Run labels cannot contain backticks or parentheses
- For the `home-index` router this produces `rule_id=home-index`, but `ruleMap` only had `"home-index-root"` — not `"home-index"`
- The provider fell back to using the literal string `"home-index"` as the Traefik rule, which is invalid — Traefik drops the catch-all router
- Without a working catch-all, paths like `/blog`, `/mitre-attack`, `/lab-01-writeup` are not routed to the home-index service

## Fix

Add `"home-index": "PathPrefix('/')"` as an alias alongside the existing `"home-index-root"` entry. Both names now resolve to the same catch-all rule.

## Test plan

- [ ] After deploying the updated provider, `labs.pcioasis.com/blog` should render the blog page (not the homepage)
- [ ] `labs.pcioasis.com/` should continue to serve the homepage
- [ ] `labs.pcioasis.com/mitre-attack` and `/lab-01-writeup` should continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)